### PR TITLE
docs: change irrelevant link to task to relevant

### DIFF
--- a/lectures/html-css-basics.md
+++ b/lectures/html-css-basics.md
@@ -14,7 +14,7 @@ https://youtu.be/OOVayP9HDTg (Part 2)
 
 ### Task
 
-https://github.com/rolling-scopes-school/tasks/blob/2017-Q3/tasks/Codecademy_HTML_CSS_Course.md
+https://github.com/rolling-scopes-school/tasks/blob/master/tasks/stage-1/HTML-CSS-self-ru.md
 
 ### Content
 1. Intro


### PR DESCRIPTION
A link to the old version of task's describe makes confusion new students when they see that both this link (https://github.com/rolling-scopes-school/tasks/blob/master/tasks/HTML_CSS_self.md) and link in the "homework" column in the schedule  (https://github.com/rolling-scopes-school/tasks/blob/master/tasks/stage-1/HTML-CSS-self-ru.md) are different